### PR TITLE
Pin coursier sbt app to the 1.x runner

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          apps: sbt
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.84.0
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,20 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": ["github-actions"]
+  "enabledManagers": ["github-actions", "custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["apps: sbt:(?<currentValue>\\S+)"],
+      "depNameTemplate": "org.scala-sbt:sbt-launch",
+      "datasourceTemplate": "maven"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["org.scala-sbt:sbt-launch"],
+      "allowedVersions": "<2.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

The latest sbt runner installed by `coursier/setup-action`'s `apps: sbt` is sbt 2.x, which requires JDK 17+ and parses CLI commands differently. This is a latent failure for the Scala Steward job, which installs sbt via coursier.

- Pin `apps: sbt:1.12.12` in `scala-steward.yml`, the only workflow that installs sbt via coursier (`test.yml` and `release.yml` use the runner's preinstalled sbt).
- Add a Renovate custom manager that tracks `org.scala-sbt:sbt-launch` from the `apps: sbt:<version>` line, capped to `<2.0.0`, so the pin stays in sync with sbt releases. `custom.regex` is added to `enabledManagers` since this repo restricts Renovate to GitHub Actions.

Generated with [Claude Code](https://claude.com/claude-code)