### PR TITLE
Cap sbt-launch pin below 1.12.13 to keep the sbt 1.x runner

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+. Renovate is constrained to
+          # not bump past this in renovate.json.
+          apps: sbt:1.12.12
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.84.0
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,9 @@
   ],
   "packageRules": [
     {
+      "description": "sbt-launch 1.12.13+ defaults to the sbt 2.x runner, which requires JDK 17+. Pin to the last sbt 1.x-default launcher.",
       "matchPackageNames": ["org.scala-sbt:sbt-launch"],
-      "allowedVersions": "<2.0.0"
+      "allowedVersions": "<1.12.13"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate bumped `apps: sbt` from `1.12.12` to `1.12.13` (#98) because the `allowedVersions` guard only blocked `2.0.0+` -- but the sbt 2.x runner default actually ships *inside* the `1.12.13` launcher, which is a `< 2.0.0` version. That launcher bypasses `project/build.properties` and resolves sbt 2.x, which requires JDK 17+ and parses CLI commands differently.

This pins the launcher back to `1.12.12` and tightens the Renovate `org.scala-sbt:sbt-launch` cap to `<1.12.13`, closing the gap that allowed #98.

Ports https://github.com/ptrdom/scalajs-esbuild/pull/672 to this repo (which only has the `scala-steward.yml` workflow installing sbt via coursier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)