### PR TITLE
Revert "Cap sbt-launch pin below 1.12.13 to keep the sbt 1.x runner"

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -16,10 +16,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
-          # sbt 2.x runner, which requires JDK 17+. Renovate is constrained to
-          # not bump past this in renovate.json.
-          apps: sbt:1.12.12
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.13
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.90.0
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -15,9 +15,8 @@
   ],
   "packageRules": [
     {
-      "description": "sbt-launch 1.12.13+ defaults to the sbt 2.x runner, which requires JDK 17+. Pin to the last sbt 1.x-default launcher.",
       "matchPackageNames": ["org.scala-sbt:sbt-launch"],
-      "allowedVersions": "<1.12.13"
+      "allowedVersions": "<2.0.0"
     }
   ]
 }


### PR DESCRIPTION
Reverts ptrdom/scripted-sbt-sources#100

This did not fix the issue, thus no point in having these changes in.