### PR TITLE
Run the Scala Steward job on JDK 17

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: coursier/setup-action@v3
         with:
-          jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          # scala-steward-action v2.90.0 bundles its own sbt 2.x runner, which
+          # requires JDK 17+ regardless of the stewarded project's sbt version.
+          jvm: temurin:17
           apps: sbt:1.12.13
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.90.0


### PR DESCRIPTION
## Summary

The Scala Steward job fails with `sbt 2.x requires JDK 17 or above, but you have JDK 11`.

`scala-steward-action` v2.90.0 installs and runs its own sbt (the `✓ SBT installed` healthcheck step), and that bundled runner is now sbt 2.x, which hard-requires JDK 17+. The job runs on `jvm: temurin:11`, so the moment scala-steward invokes sbt it aborts before it even reads the project's `build.properties`.

This is not related to the `apps: sbt` coursier pin — scala-steward does not use that sbt. Bumping this job to `temurin:17` lets the bundled sbt 2.x runner start; it then honors the project's `build.properties` (sbt 1.x) and stewarding proceeds.

Ported from ptrdom/scalajs-esbuild#673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)