### PR TITLE
Pin sbt and scalafmt versions for Scala Steward

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -20,7 +20,7 @@ jobs:
           jvm: temurin:17
           apps: sbt:1.12.13
       - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2.90.0
+        uses: scala-steward-org/scala-steward-action@v2.92.0
         with:
           github-app-id: ${{ secrets.SCALA_STEWARD_APP_ID }}
           github-app-installation-id: ${{ secrets.SCALA_STEWARD_APP_INSTALLATION_ID }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -13,15 +13,20 @@ jobs:
     runs-on: ubuntu-24.04
     name: Launch Scala Steward
     steps:
+      - uses: coursier/cache-action@v8
       - uses: coursier/setup-action@v3
         with:
-          # scala-steward-action v2.90.0 bundles its own sbt 2.x runner, which
-          # requires JDK 17+ regardless of the stewarded project's sbt version.
-          jvm: temurin:17
+          jvm: temurin:11
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
           apps: sbt:1.12.13
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.92.0
         with:
+          # Pin the sbt and scalafmt versions Scala Steward runs against to the
+          # ones used in this repository. Kept in sync by Renovate.
+          sbt-version: 1.12.13
+          scalafmt-version: 3.11.1
           github-app-id: ${{ secrets.SCALA_STEWARD_APP_ID }}
           github-app-installation-id: ${{ secrets.SCALA_STEWARD_APP_INSTALLATION_ID }}
           github-app-key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,8 @@
 updatePullRequests = "always"
+
+# sbt and scalafmt versions are pinned and updated by Renovate instead
+# (project/build.properties, .scalafmt.conf and the scala-steward workflow).
+updates.ignore = [
+  { groupId = "org.scala-sbt", artifactId = "sbt" },
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+]

--- a/renovate.json
+++ b/renovate.json
@@ -8,15 +8,46 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
-      "matchStrings": ["apps: sbt:(?<currentValue>\\S+)"],
+      "matchStrings": [
+        "apps: sbt:(?<currentValue>\\S+)",
+        "sbt-version: (?<currentValue>\\S+)"
+      ],
       "depNameTemplate": "org.scala-sbt:sbt-launch",
       "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["scalafmt-version: (?<currentValue>\\S+)"],
+      "depNameTemplate": "scalameta/scalafmt",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^project/build\\.properties$/"],
+      "matchStrings": ["sbt\\.version\\s*=\\s*(?<currentValue>\\S+)"],
+      "depNameTemplate": "org.scala-sbt:sbt-launch",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.scalafmt\\.conf$/"],
+      "matchStrings": ["version\\s*=\\s*(?<currentValue>\\S+)"],
+      "depNameTemplate": "scalameta/scalafmt",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [
     {
       "matchPackageNames": ["org.scala-sbt:sbt-launch"],
+      "groupName": "sbt",
       "allowedVersions": "<2.0.0"
+    },
+    {
+      "matchPackageNames": ["scalameta/scalafmt"],
+      "groupName": "scalafmt"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Port of ptrdom/scalajs-vite#481: hand the sbt and scalafmt version bumps to Renovate and have Scala Steward ignore them, so the two tools no longer race to update `project/build.properties`, `.scalafmt.conf` and the workflow.
- Pins the `scala-steward-action` run to the sbt 1.x runner on JDK 11 (sbt 2.x needs JDK 17+) and adds `coursier/cache-action` to speed up steward runs.

Generated with [Claude Code](https://claude.com/claude-code)
