### PR TITLE
Install sbt via coursier in release and test workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
+          # ubuntu-24.04 runners no longer ship sbt preinstalled, so install
+          # it via coursier. Pin to the sbt 1.x runner (2.x requires JDK 17+).
+          # Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.13
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
+          # ubuntu-24.04 runners no longer ship sbt preinstalled, so install
+          # it via coursier. Pin to the sbt 1.x runner (2.x requires JDK 17+).
+          # Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.13
       - name: Run tests
         run: sbt scalafmtSbtCheck scalafmtCheckAll test scripted

--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,14 @@
       "depNameTemplate": "scalameta/scalafmt",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/test\\.ya?ml$/"],
+      "matchStrings": ["ubuntu-(?<currentValue>\\d+\\.\\d+)"],
+      "depNameTemplate": "ubuntu",
+      "datasourceTemplate": "github-runners",
+      "versioningTemplate": "ubuntu"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

The `Release` workflow has been failing on `main` with `sbt: command not found` (exit 127). PR #37 bumped `release.yml` to `runs-on: ubuntu-24.04`, and that runner image no longer ships sbt preinstalled (ubuntu-22.04 did). Both `release.yml` and `test.yml` relied on the preinstalled sbt via `coursier/setup-action` with only `jvm` set.

- Add `apps: sbt:1.12.13` to the `coursier/setup-action` step in `release.yml` and `test.yml`, matching `scala-steward.yml`. The existing `apps: sbt:` Renovate regex manager already tracks any workflow file, so these pins stay in sync automatically.
- `test.yml` is currently green only because it still runs on `ubuntu-22.04` (and `windows-latest`), which have sbt preinstalled; pinning proactively keeps it working when those runners move to ubuntu-24.04.
- Add a Renovate custom manager tracking the Ubuntu runner version in `test.yml`'s build matrix (`os: [ubuntu-22.04, …]`). The built-in github-actions manager only parses scalar `runs-on:` values (as in `release.yml`, which produced #37), not matrix arrays, so `test.yml`'s runner was never being updated. The manager is scoped to `test.yml` only to avoid double-tracking `release.yml`.
