### PR TITLE
Pin Scala Steward to 0.39.0, the last Java 11 build

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.92.0
         with:
+          # Pin Scala Steward itself. The action otherwise downloads the latest
+          # published version on every run; 0.39.1 dropped the Java 11 build and
+          # requires Java 17+, which breaks the temurin:11 runner above. Renovate
+          # tracks this pin; a bump past 0.39.0 fails on first run until the
+          # runner is moved to JDK 17.
+          scala-steward-version: 0.39.0
           # Pin the sbt and scalafmt versions Scala Steward runs against to the
           # ones used in this repository. Kept in sync by Renovate.
           sbt-version: 1.12.13

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,14 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["scala-steward-version: (?<currentValue>\\S+)"],
+      "depNameTemplate": "scala-steward-org/scala-steward",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^project/build\\.properties$/"],
       "matchStrings": ["sbt\\.version\\s*=\\s*(?<currentValue>\\S+)"],
       "depNameTemplate": "org.scala-sbt:sbt-launch",
@@ -56,6 +64,11 @@
     {
       "matchPackageNames": ["scalameta/scalafmt"],
       "groupName": "scalafmt"
+    },
+    {
+      "description": "Pinned to 0.39.0, the last Java 11 build; 0.39.1+ requires Java 17+ and will fail on the temurin:11 runner in scala-steward.yml. Bump PRs are intentionally left uncapped: a bump beyond 0.39.0 fails first run and is resolved by moving the runner to JDK 17.",
+      "matchPackageNames": ["scala-steward-org/scala-steward"],
+      "groupName": "scala-steward"
     }
   ]
 }


### PR DESCRIPTION
Pins Scala Steward to `0.39.0`, the last release with a Java 11 build.

The `scala-steward-action` downloads the latest published Scala Steward on every run. Version `0.39.1` dropped the Java 11 build and requires Java 17+, which would break the `temurin:11` runner in `scala-steward.yml` the next time the action pulls a newer version.

- `.github/workflows/scala-steward.yml` — adds `scala-steward-version: 0.39.0` with a comment explaining the pin.
- `renovate.json` — adds a custom regex manager tracking `scala-steward-version` (via the `scala-steward-org/scala-steward` GitHub releases datasource) and a package rule grouping its updates under `scala-steward`.

Bump PRs are intentionally left uncapped: a bump beyond `0.39.0` will fail on first run and is resolved by moving the runner to JDK 17.
